### PR TITLE
s/lodash.isArray/lodash.isarray

### DIFF
--- a/src/executehandler.js
+++ b/src/executehandler.js
@@ -1,7 +1,7 @@
 'use strict';
 var highland = require('highland');
 var _ = {
-  isArray: require('lodash.isArray')
+  isArray: require('lodash.isarray')
 };
 
 function defaultExecuteHandler(messageStream, callback) {


### PR DESCRIPTION
The package's actual name and location on disk is lodash.isarray.  On
case-insensitive filesystems like HFS+ (used primarily by Mac OS X), the
fs operations performed by `require("lodash.isArray")` end up locating
the module even though the case in the require directive doesn't match
the case in the directory on disk.  On case-sensitive filesystems like
ex4 (used primarily by Linux operating systems), these fs operations do
not succeed in locating the directory and an exception is thrown.