### PR TITLE
issue #29 . Sending as Binary.

### DIFF
--- a/src/GremlinClient.js
+++ b/src/GremlinClient.js
@@ -66,7 +66,7 @@ class GremlinClient extends EventEmitter {
    */
   handleProtocolMessage(message) {
     const reader = new FileReader();
-    reader.addEventListener("loadend", (function() {
+    reader.addEventListener("loadend", () => {
       const messageData = String.fromCharCode.apply(null, new Uint8Array(reader.result));
       const rawMessage = JSON.parse(messageData);
       const {
@@ -98,7 +98,7 @@ class GremlinClient extends EventEmitter {
           messageStream.emit('error', new Error(statusMessage + ' (Error '+ statusCode +')'));
           break;
       }
-    }).bind(this));
+    });
     reader.readAsArrayBuffer(message.data || message); // Node.js || Browser API
   }
 
@@ -189,9 +189,9 @@ class GremlinClient extends EventEmitter {
     const serializedMessage = this.options.accept + JSON.stringify(message);
 
     //Lets start packing the message into binary
-    var pack = new Uint8Array(1 + serializedMessage.length);//mimeLength(1) + mimeType Length + serializedMessage Length
+    let pack = new Uint8Array(1 + serializedMessage.length);//mimeLength(1) + mimeType Length + serializedMessage Length
     pack[0] = this.options.accept.length;
-    for (var i = 0, len = serializedMessage.length; i < len; i++) {
+    for (let i = 0, len = serializedMessage.length; i < len; i++) {
       pack[i+1] = serializedMessage.charCodeAt(i);
     }
     this.connection.sendMessage(pack);

--- a/src/WebSocketGremlinConnection.js
+++ b/src/WebSocketGremlinConnection.js
@@ -36,7 +36,7 @@ export default class WebSocketGremlinConnection extends EventEmitter {
   }
 
   sendMessage(message) {
-    this.ws.send(message, (err) => {
+    this.ws.send(message, {mask: true, binary: true}, (err) => {
       if (err) {
         this.handleError(err);
       }


### PR DESCRIPTION
This should correct the issue with the client not communicating the `mimeType` to the server.

What the PR covers:

- `WebSocketGremlinConnection` now sends messages as `binary` and `masked`
- `GremlinClient` now packs the request messages in binary with the included `mimeType` headers
- `GremlinClient` now unpacks the binary Blob response sent back from the server

I wasn't able to get `npm run test:node` to work, got some strange legacy node error ; I think my env isn't setup correctly. So this **will need testing** as I only have some manual testing going for this PR at the moment.

FYI, my manual testing covers:
- `application/json` simple send and reading response (haven't tried any streaming)
- Custom mimeType `application/gremlinbin` same as above