### PR TITLE
minor tweaks for browser end support of binary

### DIFF
--- a/src/GremlinClient.js
+++ b/src/GremlinClient.js
@@ -66,7 +66,8 @@ class GremlinClient extends EventEmitter {
    */
   handleProtocolMessage(message) {
     const { data } = message;
-    const rawMessage = JSON.parse(data.toString());
+    const buffer = new Buffer(data, 'binary');
+    const rawMessage = JSON.parse(buffer.toString('utf-8'));
     const {
       requestId,
       status: {

--- a/src/WebSocketGremlinConnection.js
+++ b/src/WebSocketGremlinConnection.js
@@ -15,6 +15,7 @@ export default class WebSocketGremlinConnection extends EventEmitter {
     this.ws.onerror = (err) => this.handleError(err);
     this.ws.onmessage = (message) => this.handleMessage(message);
     this.ws.onclose = (event) => this.onClose(event);
+    this.ws.binaryType = "arraybuffer";
   }
 
   onOpen() {


### PR DESCRIPTION
Seems to work for my versions of chrome safari and firefox at least. Now hopefully also works on node though it might need adjusting with a conditional statement checking the type of `data` before the buffer is created.