### PR TITLE
Some fixes for examples. Incomplete.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,13 +260,13 @@ This section assumes that loaded the default TinkerPop graph with `scripts: [scr
 To run the command line example:
 ```
 cd examples
-node node-example
+../node_modules/.bin/babel-node node-example
 ```
 
 To run the browser example:
 ```
 cd examples
-node server
+../node_modules/.bin/babel-node server
 ```
 then open [http://localhost:3000/examples/gremlin.html](http://localhost:3000/examples/gremlin.html) for a demonstration on how a list of 6 vertices is being populated as the vertices are being streamed down from Gremlin Server.
 

--- a/examples/node-example-function-inline.js
+++ b/examples/node-example-function-inline.js
@@ -1,4 +1,4 @@
-var gremlin = require('../');
+var gremlin = require('../src');
 
 var client = gremlin.createClient(8182, 'localhost', { language: 'nashorn' });
 

--- a/examples/node-example-function.js
+++ b/examples/node-example-function.js
@@ -1,4 +1,4 @@
-var gremlin = require('../');
+var gremlin = require('../src');
 
 var client = gremlin.createClient(8182, 'localhost', { language: 'nashorn' });
 

--- a/examples/node-example-session.js
+++ b/examples/node-example-session.js
@@ -1,4 +1,4 @@
-var gremlin = require('../');
+var gremlin = require('../src');
 
 var client = gremlin.createClient(8182, 'localhost', { session: true });
 

--- a/examples/node-example.js
+++ b/examples/node-example.js
@@ -1,4 +1,4 @@
-var gremlin = require('../');
+var gremlin = require('../src');
 
 var client = gremlin.createClient();
 


### PR DESCRIPTION
This PR is a discussion point. I think that accepting it into the current repo in this state would make the examples no less broken but also does not completely fix the issue. I could have also completely misunderstood what's going on and this PR may be useless. I'm now getting this:

```
[Error: No signature of method: org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal.getAt() is applicable for argument types: (groovy.lang.IntRange) values: [1..2]
Possible solutions: getAt(int), getAt(java.lang.String), next(), reset(), putAt(java.lang.String, java.lang.Object), wait() (Error 597)] undefined
[Error: Error: No signature of method: org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal.getAt() is applicable for argument types: (groovy.lang.IntRange) values: [1..2]
Possible solutions: getAt(int), getAt(java.lang.String), next(), reset(), putAt(java.lang.String, java.lang.Object), wait() (Error 597)]
```

Looking for some help on the above error.