### PR TITLE
Update ws dependency to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "^3.10.1",
     "node-uuid": "^1.4.3",
     "readable-stream": "^2.0.2",
-    "ws": "^0.8.0"
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/src/GremlinClient.js
+++ b/src/GremlinClient.js
@@ -220,8 +220,8 @@ class GremlinClient extends EventEmitter {
    * @param {Object} message
    * @param {Function} callback
    */
-  execute(script, bindings = {}, message = {}, ...args) {
-    let callback = args[args.length - 1];
+  execute(script, bindings = {}, message = {}) {
+    let callback = arguments[arguments.length - 1];
 
     if (typeof message === 'function') {
       callback = message;


### PR DESCRIPTION
Bumps the `ws` dependency up to 1.x, resolving issues like those seen in #60.

Also fixes the `execute()` method to work with the updated version of babel, which doesn't generate the same code for methods that combine optional and rest parameters as previous versions (a.k.a. what built version 2.3.2 of this library)