### PR TITLE
add client.terminate()

### DIFF
--- a/src/GremlinClient.js
+++ b/src/GremlinClient.js
@@ -388,6 +388,22 @@ class GremlinClient extends EventEmitter {
 
     return awaitable;
   }
+
+  /**
+   * Terminate WebSocket Connection after make sure all commands have been
+   * Executed Successfully.
+   */
+  terminate() {
+    let commands = this.commands;
+    let connection = this.connection;
+    setInterval(function(){
+      if(Object.keys(commands).length === 0) {
+        this.connected = false;
+        connection.terminate();
+        clearInterval(this);
+      }
+    }, 100);
+  }
 }
 
 export default GremlinClient;

--- a/src/WebSocketGremlinConnection.js
+++ b/src/WebSocketGremlinConnection.js
@@ -41,6 +41,10 @@ export default class WebSocketGremlinConnection extends EventEmitter {
     this.emit('close', event);
   }
 
+  terminate() {
+      this.open = false;
+      this.ws.close();
+    }
   sendMessage(message) {
     this.ws.send(message, { mask: true, binary: true }, (err) => {
       if (err) {


### PR DESCRIPTION
enable the client to close the web socket once they're need it, this method will make sure all commands have been done executing and then it will close the socket

```
let gremlin = require('gremlin-secure');
const client = gremlin.createClient(
        443,
        "someURL.graphs.azure.com",
        {
            session: false,
            ssl: true,
            user: "/dbs/test/colls/test",
            password: "secretPassword"
        }
        );
for(var i =0; i < 30; i++){
      client.execute('g.V().has("id", id)', { id: 'shahin' }, (err, results) => {
          if (err) {
              return console.error(err)
          }
          console.log(results);
      });
}
client.terminate();
```