### PR TITLE
Proxy support

### DIFF
--- a/gremlin-client/package.json
+++ b/gremlin-client/package.json
@@ -20,7 +20,7 @@
     "test:watch": "npm run test -- --watch"
   },
   "lint-staged": {
-    "gitDir": "../",    
+    "gitDir": "../",
     "*.js": [
       "npm run prettify",
       "git add"
@@ -46,9 +46,13 @@
   "dependencies": {
     "gremlin-template-string": "^2.0.0",
     "highland": "^2.5.1",
+    "https-proxy-agent": "^2.1.0",
     "lodash": "^3.10.1",
+    "net": "^1.0.2",
     "node-uuid": "^1.4.3",
     "readable-stream": "^2.0.2",
+    "tls": "0.0.1",
+    "url": "^0.11.0",
     "utf8": "^2.0.0",
     "ws": "^2.3.1",
     "zer": "^0.1.0"

--- a/gremlin-client/src/WebSocketGremlinConnection.js
+++ b/gremlin-client/src/WebSocketGremlinConnection.js
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events';
 
 import WebSocket from 'ws';
+import Url from 'url';
+import HttpsProxyAgent from 'https-proxy-agent';
 
 export default class WebSocketGremlinConnection extends EventEmitter {
   constructor({ port, host, path, ssl, rejectUnauthorized }) {
@@ -13,7 +15,15 @@ export default class WebSocketGremlinConnection extends EventEmitter {
       rejectUnauthorized,
     };
 
-    this.ws = new WebSocket(address, null, options);
+    var proxy = process.env.http_proxy;
+    var agent_options = null;
+    var custom_agent = null;
+    if (proxy) {
+      agent_options = Url.parse(proxy);
+      var agent = new HttpsProxyAgent(agent_options);
+      custom_agent = { agent: agent };
+    }
+    this.ws = new WebSocket(address, custom_agent, options);
 
     this.ws.onopen = () => this.onOpen();
     this.ws.onerror = err => this.handleError(err);


### PR DESCRIPTION
I could not connect to titan from my Node.js project when running behind corporate proxy. I had to modify code slightly based on https://github.com/websockets/ws#how-to-connect-via-a-proxy.
