### PR TITLE
Add missing close method.

### DIFF
--- a/gremlin-client/src/WebSocketGremlinConnection.js
+++ b/gremlin-client/src/WebSocketGremlinConnection.js
@@ -34,7 +34,11 @@ export default class WebSocketGremlinConnection extends EventEmitter {
   handleMessage(message) {
     this.emit('message', message);
   }
-
+  
+  close() {
+    this.ws.terminate();
+  }
+  
   onClose(event) {
     this.open = false;
     this.emit('close', event);


### PR DESCRIPTION
Fixes  #9 

This method is actually expected to exist by GremlinClient:
https://github.com/jbmusso/gremlin-javascript/blob/7cb7544dfbdf89f2a2863471f226825a2357b994/gremlin-client/src/GremlinClient.js#L84