### PR TITLE
Switch from node-uuid to uuid

### DIFF
--- a/gremlin-client/package.json
+++ b/gremlin-client/package.json
@@ -20,7 +20,7 @@
     "test:watch": "npm run test -- --watch"
   },
   "lint-staged": {
-    "gitDir": "../",    
+    "gitDir": "../",
     "*.js": [
       "npm run prettify",
       "git add"
@@ -47,8 +47,8 @@
     "gremlin-template-string": "^2.0.0",
     "highland": "^2.5.1",
     "lodash": "^3.10.1",
-    "node-uuid": "^1.4.3",
     "readable-stream": "^2.0.2",
+    "uuid": "^3.2.1",
     "ws": "^2.3.1",
     "zer": "^0.1.0"
   },

--- a/gremlin-client/src/GremlinClient.js
+++ b/gremlin-client/src/GremlinClient.js
@@ -2,7 +2,7 @@
 /*jslint node: true */
 import { EventEmitter } from 'events';
 
-import uuid from 'node-uuid';
+import uuidV1 from 'uuid/v1';
 import _ from 'lodash';
 import highland from 'highland';
 import { gremlin, renderChain } from 'zer';
@@ -43,7 +43,7 @@ class GremlinClient extends EventEmitter {
     this.password = this.options.password;
 
     if (this.useSession) {
-      this.sessionId = uuid.v1();
+      this.sessionId = uuidV1();
     }
 
     this.connected = false;
@@ -225,7 +225,7 @@ class GremlinClient extends EventEmitter {
     const args = _.defaults(baseMessage.args || {}, baseArgs);
 
     const message = {
-      requestId: uuid.v1(),
+      requestId: uuidV1(),
       processor,
       op,
       args,

--- a/gremlin-client/yarn.lock
+++ b/gremlin-client/yarn.lock
@@ -2704,10 +2704,6 @@ node-pre-gyp@^0.6.39:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-uuid@^1.4.3:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -3816,7 +3812,7 @@ util@0.10.3, util@^0.10.3, util@~0.10.1:
   dependencies:
     inherits "2.0.1"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
A minor change. `node-uuid` has merged with `uuid` a while back (seen [here](https://www.npmjs.com/package/node-uuid)) and the published version of `node-uuid` is no longer maintained. It would be best to switch over to `uuid`.