### PR TITLE
Attach rawMessage property to error on execute()

### DIFF
--- a/gremlin-client/src/GremlinClient.js
+++ b/gremlin-client/src/GremlinClient.js
@@ -146,10 +146,9 @@ class GremlinClient extends EventEmitter {
         break;
       default:
         delete this.commands[requestId];
-        messageStream.emit(
-          'error',
-          new Error(statusMessage + ' (Error ' + statusCode + ')'),
-        );
+        const error = new Error(statusMessage + ' (Error ' + statusCode + ')');
+        error.rawMessage = rawMessage;
+        messageStream.emit('error', error);
         break;
     }
   }

--- a/gremlin-client/src/execute.test.js
+++ b/gremlin-client/src/execute.test.js
@@ -1,5 +1,5 @@
 require('chai').should();
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import gremlin, { statics } from './';
 
 import { get } from 'lodash';
@@ -110,6 +110,8 @@ describe('.execute()', function() {
 
     client.execute(script, function(err, result) {
       (err === null).should.be.false;
+      expect(err.rawMessage).to.have.property('status');
+      expect(err.rawMessage).to.have.property('requestId');
       done();
     });
   });


### PR DESCRIPTION
Some gremlin-compatible endpoints (such as [Azure CosmosDB Graph](https://docs.microsoft.com/en-us/azure/cosmos-db/graph-introduction)) provide additional metadata in the message which is useful for processing. It's possible to retrieve this information using a custom `executeHandler`, but the metadata is swallowed when an error occurs, making it impossible for a client to retrieve it.

This change adds a `rawMessage` property to the error emitted so that clients can retrieve additional structured information from the message when errors occur. I'm also open to any suggestions for other approaches/field names. I went with this because it was simple and non-breaking without limiting the available information.